### PR TITLE
Add Dutch (and Belgian Dutch) matching labels

### DIFF
--- a/src/matching/autocomplete-dict.json
+++ b/src/matching/autocomplete-dict.json
@@ -1025,8 +1025,7 @@
             "maand"
         ],
         "40": [
-            "geboortejaar",
-            "jaar"
+            "geboortejaar"
         ],
         "41": [
             "geslacht",
@@ -1065,7 +1064,7 @@
             "mobiel",
             "gsm",
             "werktelefoon",
-            "thuisnummer",
+            "thuisnummer"
         ],
         "45": [
             "landcode",
@@ -1131,7 +1130,6 @@
     "byFormType_NL": {
         "login": [
             "login",
-            "log in",
             "inloggen",
             "aanloggen",
             "aanmelden"

--- a/src/matching/autocomplete-dict.json
+++ b/src/matching/autocomplete-dict.json
@@ -56,150 +56,1096 @@
     },
     "byInputType": {
         "button": [],
-        "checkbox": [2,6,33,34,36,41,45],
+        "checkbox": [
+            2,
+            6,
+            33,
+            34,
+            36,
+            41,
+            45
+        ],
         "color": [],
-        "date": [37],
+        "date": [
+            37
+        ],
         "datetime-local": [],
-        "email": [9,52],
+        "email": [
+            9,
+            52
+        ],
         "file": [],
         "hidden": [],
         "image": [],
-        "month": [29],
-        "number": [23,28,29,30,31,32,35,38,39,40,44,45,46,47,48,49,50,51],
-        "password": [10,11],
+        "month": [
+            29
+        ],
+        "number": [
+            23,
+            28,
+            29,
+            30,
+            31,
+            32,
+            35,
+            38,
+            39,
+            40,
+            44,
+            45,
+            46,
+            47,
+            48,
+            49,
+            50,
+            51
+        ],
+        "password": [
+            10,
+            11
+        ],
         "radio": [],
-        "range": [35],
+        "range": [
+            35
+        ],
         "reset": [],
         "search": [],
         "submit": [],
-        "tel": [44],
-        "text": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53],
+        "tel": [
+            44
+        ],
+        "text": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,
+            30,
+            31,
+            32,
+            33,
+            34,
+            35,
+            36,
+            37,
+            38,
+            39,
+            40,
+            41,
+            42,
+            43,
+            44,
+            45,
+            46,
+            47,
+            48,
+            49,
+            50,
+            51,
+            52,
+            53
+        ],
         "time": [],
-        "url": [42,43,53],
+        "url": [
+            42,
+            43,
+            53
+        ],
         "week": [],
         "datetime": []
     },
     "byFieldType": {
-        "input": [1,2,3,4,5,6,7,8,9,10,11,12,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53],
-        "textarea": [13,42,43,44],
-        "select": [2,6,8,21,22,33,34,36,38,39,40,41,45]
+        "input": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,
+            30,
+            31,
+            32,
+            33,
+            34,
+            35,
+            36,
+            37,
+            38,
+            39,
+            40,
+            41,
+            42,
+            43,
+            44,
+            45,
+            46,
+            47,
+            48,
+            49,
+            50,
+            51,
+            52,
+            53
+        ],
+        "textarea": [
+            13,
+            42,
+            43,
+            44
+        ],
+        "select": [
+            2,
+            6,
+            8,
+            21,
+            22,
+            33,
+            34,
+            36,
+            38,
+            39,
+            40,
+            41,
+            45
+        ]
     },
-    "byLabel_EN":{
-        "1": ["name", "fullname"],
-        "2": ["honorificprefix", "honorific", "prefix"],
-        "3": ["givenname", "firstname", "forename", "callname"],
-        "4": ["additionalname", "middlename"],
-        "5": ["familyname", "lastname", "surname"],
-        "6": ["honorificsuffix", "honorific", "suffix"],
-        "7": ["nickname", "nick", "screenname", "alias"],
-        "8": ["organizationtitle", "jobtitle", "title"],
-        "9": ["username"],
-        "10": ["newpassword"],
-        "11": ["currentpassword", "password"],
-        "12": ["organization", "company", "companyname"],
-        "13": ["streetaddress", "address"],
-        "14": ["streetaddress", "address", "line1"],
-        "15": ["streetaddress", "address", "line2"],
-        "16": ["streetaddress", "address", "line3"],
-        "17": ["level4", "address", "town", "city"],
-        "18": ["level3", "address", "district"],
-        "19": ["level2", "address", "town", "city"],
-        "20": ["level1", "address", "state", "town", "province, prefecture"],
-        "21": ["country", "countrycode"],
-        "22": ["country", "countryname"],
-        "23": ["postalcode", "zip", "zipcode", "postcode", "cedex"],
-        "24": ["ccname", "creditcardname", "cardholder", "cardowner", "nameoncard"],
-        "25": ["ccgivenname", "creditcardgivenname", "creditcardfirstname", "creditcardforename", "creditcardcallname"],
-        "26": ["ccadditionalname", "ccmiddlename", "creditcardadditionbalname", "creditcardmiddlename"],
-        "27": ["ccfamilyname", "cclastname", "ccsurname", "creditcardfamilyname", "creditcardlastname", "creditcardsurname"],
-        "28": ["ccnumber", "creditcardnumber", "cardnumber", "cardno"],
-        "29": ["expirationdate", "expires", "expiration"],
-        "30": ["expirationmonth", "expiresmonth"],
-        "31": ["expirationyear", "expiresyear"],
-        "32": ["securitycode", "security", "csc", "cardsecuritycode", "cvc", "cardvalidationcode", "cvv", "cardverificationvalue", "spc", "signaturepanelcode", "ccid", "creditcardid"],
-        "33": ["payment", "paymentprovider", "provider", "visa", "mastercard", "paypal"],
-        "34": ["transactioncurrency", "currency", "eur", "usd", "gbp", "chf"],
-        "35": ["transactionamount", "amount"],
-        "36": ["language"],
-        "37": ["birthday", "bday"],
-        "38": ["birthdayday, bdayday", "day"],
-        "39": ["birthdaymonth", "bdaymonth", "birthmonth", "month"],
-        "40": ["birthyear", "bdayyear", "birthdayyear"],
-        "41": ["sex", "gender", "genderidentity", "identity", "male", "female", "transgender", "trans", "queer", "other"],
-        "42": ["url", "link", "homepage", "webpage", "site", "website"],
-        "43": ["photo", "photograph", "icon", "image"],
-        "44": ["tel", "telephone", "telephonenumber", "mobile", "mobilephone", "mobilenumber", "mobileno"],
-        "45": ["countrycode", "isd", "countrycallingcode"],
-        "46": ["telnational"],
-        "47": ["telareacode", "areacode", "area"],
-        "48": ["tellocal", "local"],
-        "49": ["tellocalprefix", "localprefix"],
-        "50": ["tellocalsuffix", "localsuffix"],
-        "51": ["telextension", "internalextension", "extension", "internal"],
-        "52": ["email", "emil", "emailaddress"],
-        "53": ["impp", "instantmessagingprotocol", "instantmessagingprotocolendpoint"]
+    "byLabel_EN": {
+        "1": [
+            "name",
+            "fullname"
+        ],
+        "2": [
+            "honorificprefix",
+            "honorific",
+            "prefix"
+        ],
+        "3": [
+            "givenname",
+            "firstname",
+            "forename",
+            "callname"
+        ],
+        "4": [
+            "additionalname",
+            "middlename"
+        ],
+        "5": [
+            "familyname",
+            "lastname",
+            "surname"
+        ],
+        "6": [
+            "honorificsuffix",
+            "honorific",
+            "suffix"
+        ],
+        "7": [
+            "nickname",
+            "nick",
+            "screenname",
+            "alias"
+        ],
+        "8": [
+            "organizationtitle",
+            "jobtitle",
+            "title"
+        ],
+        "9": [
+            "username"
+        ],
+        "10": [
+            "newpassword"
+        ],
+        "11": [
+            "currentpassword",
+            "password"
+        ],
+        "12": [
+            "organization",
+            "company",
+            "companyname"
+        ],
+        "13": [
+            "streetaddress",
+            "address"
+        ],
+        "14": [
+            "streetaddress",
+            "address",
+            "line1"
+        ],
+        "15": [
+            "streetaddress",
+            "address",
+            "line2"
+        ],
+        "16": [
+            "streetaddress",
+            "address",
+            "line3"
+        ],
+        "17": [
+            "level4",
+            "address",
+            "town",
+            "city"
+        ],
+        "18": [
+            "level3",
+            "address",
+            "district"
+        ],
+        "19": [
+            "level2",
+            "address",
+            "town",
+            "city"
+        ],
+        "20": [
+            "level1",
+            "address",
+            "state",
+            "town",
+            "province, prefecture"
+        ],
+        "21": [
+            "country",
+            "countrycode"
+        ],
+        "22": [
+            "country",
+            "countryname"
+        ],
+        "23": [
+            "postalcode",
+            "zip",
+            "zipcode",
+            "postcode",
+            "cedex"
+        ],
+        "24": [
+            "ccname",
+            "creditcardname",
+            "cardholder",
+            "cardowner",
+            "nameoncard"
+        ],
+        "25": [
+            "ccgivenname",
+            "creditcardgivenname",
+            "creditcardfirstname",
+            "creditcardforename",
+            "creditcardcallname"
+        ],
+        "26": [
+            "ccadditionalname",
+            "ccmiddlename",
+            "creditcardadditionbalname",
+            "creditcardmiddlename"
+        ],
+        "27": [
+            "ccfamilyname",
+            "cclastname",
+            "ccsurname",
+            "creditcardfamilyname",
+            "creditcardlastname",
+            "creditcardsurname"
+        ],
+        "28": [
+            "ccnumber",
+            "creditcardnumber",
+            "cardnumber",
+            "cardno"
+        ],
+        "29": [
+            "expirationdate",
+            "expires",
+            "expiration"
+        ],
+        "30": [
+            "expirationmonth",
+            "expiresmonth"
+        ],
+        "31": [
+            "expirationyear",
+            "expiresyear"
+        ],
+        "32": [
+            "securitycode",
+            "security",
+            "csc",
+            "cardsecuritycode",
+            "cvc",
+            "cardvalidationcode",
+            "cvv",
+            "cardverificationvalue",
+            "spc",
+            "signaturepanelcode",
+            "ccid",
+            "creditcardid"
+        ],
+        "33": [
+            "payment",
+            "paymentprovider",
+            "provider",
+            "visa",
+            "mastercard",
+            "paypal"
+        ],
+        "34": [
+            "transactioncurrency",
+            "currency",
+            "eur",
+            "usd",
+            "gbp",
+            "chf"
+        ],
+        "35": [
+            "transactionamount",
+            "amount"
+        ],
+        "36": [
+            "language"
+        ],
+        "37": [
+            "birthday",
+            "bday"
+        ],
+        "38": [
+            "birthdayday, bdayday",
+            "day"
+        ],
+        "39": [
+            "birthdaymonth",
+            "bdaymonth",
+            "birthmonth",
+            "month"
+        ],
+        "40": [
+            "birthyear",
+            "bdayyear",
+            "birthdayyear"
+        ],
+        "41": [
+            "sex",
+            "gender",
+            "genderidentity",
+            "identity",
+            "male",
+            "female",
+            "transgender",
+            "trans",
+            "queer",
+            "other"
+        ],
+        "42": [
+            "url",
+            "link",
+            "homepage",
+            "webpage",
+            "site",
+            "website"
+        ],
+        "43": [
+            "photo",
+            "photograph",
+            "icon",
+            "image"
+        ],
+        "44": [
+            "tel",
+            "telephone",
+            "telephonenumber",
+            "mobile",
+            "mobilephone",
+            "mobilenumber",
+            "mobileno"
+        ],
+        "45": [
+            "countrycode",
+            "isd",
+            "countrycallingcode"
+        ],
+        "46": [
+            "telnational"
+        ],
+        "47": [
+            "telareacode",
+            "areacode",
+            "area"
+        ],
+        "48": [
+            "tellocal",
+            "local"
+        ],
+        "49": [
+            "tellocalprefix",
+            "localprefix"
+        ],
+        "50": [
+            "tellocalsuffix",
+            "localsuffix"
+        ],
+        "51": [
+            "telextension",
+            "internalextension",
+            "extension",
+            "internal"
+        ],
+        "52": [
+            "email",
+            "emil",
+            "emailaddress"
+        ],
+        "53": [
+            "impp",
+            "instantmessagingprotocol",
+            "instantmessagingprotocolendpoint"
+        ]
     },
-    "byLabel_DE":{
-        "1": ["name", "vorundnachname"],
-        "2": ["anrede", "titel", "prefix"],
-        "3": ["vorname", "rufname"],
-        "4": ["zweitname", "zwischenname", "mittelname"],
-        "5": ["nachname", "familienname"],
-        "6": ["namenszusatz", "zusatz", "suffix"],
-        "7": ["alias", "künstlername", "spitzname"],
-        "8": ["beruf", "titel", "jobbezeichnung"],
-        "9": ["benutzername"],
-        "10": ["neuespasswort"],
-        "11": ["aktuellespasswort", "passwort"],
-        "12": ["organisation", "firma", "betrieb", "konzern", "geschäft"],
-        "13": ["adresse", "straßehausnummer"],
-        "14": ["adresszeile1", "zeile1", "straße", "hausnummer", "hausnr"],
-        "15": ["adresszeile2", "zeile2", "hausnummer", "hausnr", "appartment"],
-        "16": ["adresszeile3", "zeile3"],
-        "17": ["level4"],
-        "18": ["level3", "stadtteil", "bezirk", "ortsteil"],
-        "19": ["level2", "stadt", "dorf", "ort"],
-        "20": ["level1", "bundesland", "kanton"],
-        "21": ["ländercode", "code"],
-        "22": ["ländername", "landname", "land"],
-        "23": ["postleitzahl", "plz"],
-        "24": ["kreditkartenname", "namedeskarteninhabers", "karteninhaber", "kartenbesitzer", "kontoinhaber"],
-        "25": ["kreditkartenvorname"],
-        "26": ["kreditkartenzweitname", "kreditkartenzwischenname", "kreditkartenmittelname"],
-        "27": ["kreditkartennachname"],
-        "28": ["kreditkartennummer", "iban", "kartennummer"],
-        "29": ["verfallsdatum", "läuftab", "gültig", "gültigbis"],
-        "30": ["ablaufmonat", "gültigbismonat", "bismonat"],
-        "31": ["ablaufjahr", "gültigbisjahr", "bisjahr"],
-        "32": ["sicherheitscode", "prüfziffer", "csc", "cvc", "cvv", "spc", "ccid"],
-        "33": ["zahlungsmethode", "zahlungsanbieter", "anbieter", "visa", "mastercard", "paypal"],
-        "34": ["währung", "transaktionswährung", "eur", "usd", "gbp", "chf"],
-        "35": ["transaktionsbetrag", "betrag"],
-        "36": ["sprache"],
-        "37": ["geburtstag", "geburtsdatum"],
-        "38": ["geburtstagtag", "tag"],
-        "39": ["geburtstagmonat", "monat"],
-        "40": ["geburtsjahr"],
-        "41": ["geschlecht", "gender", "geschlechtsidentität", "identität", "mann", "frau", "divers", "transgender", "trans", "queer", "other"],
-        "42": ["url", "link", "homepage", "webseite", "seite"],
-        "43": ["foto", "bild", "icon"],
-        "44": ["tel", "telefon", "telefonnummer", "handy", "mobiltelefon", "mobilnummer", "mobilfunknummer", "mobil"],
-        "45": ["ländervorwahl", "vorwahldeslandes", "vorwahldeslands", "internationalevorwahl"],
-        "46": ["nationaletelefonnummer"],
-        "47": ["vorwahl"],
+    "byLabel_DE": {
+        "1": [
+            "name",
+            "vorundnachname"
+        ],
+        "2": [
+            "anrede",
+            "titel",
+            "prefix"
+        ],
+        "3": [
+            "vorname",
+            "rufname"
+        ],
+        "4": [
+            "zweitname",
+            "zwischenname",
+            "mittelname"
+        ],
+        "5": [
+            "nachname",
+            "familienname"
+        ],
+        "6": [
+            "namenszusatz",
+            "zusatz",
+            "suffix"
+        ],
+        "7": [
+            "alias",
+            "künstlername",
+            "spitzname"
+        ],
+        "8": [
+            "beruf",
+            "titel",
+            "jobbezeichnung"
+        ],
+        "9": [
+            "benutzername"
+        ],
+        "10": [
+            "neuespasswort"
+        ],
+        "11": [
+            "aktuellespasswort",
+            "passwort"
+        ],
+        "12": [
+            "organisation",
+            "firma",
+            "betrieb",
+            "konzern",
+            "geschäft"
+        ],
+        "13": [
+            "adresse",
+            "straßehausnummer"
+        ],
+        "14": [
+            "adresszeile1",
+            "zeile1",
+            "straße",
+            "hausnummer",
+            "hausnr"
+        ],
+        "15": [
+            "adresszeile2",
+            "zeile2",
+            "hausnummer",
+            "hausnr",
+            "appartment"
+        ],
+        "16": [
+            "adresszeile3",
+            "zeile3"
+        ],
+        "17": [
+            "level4"
+        ],
+        "18": [
+            "level3",
+            "stadtteil",
+            "bezirk",
+            "ortsteil"
+        ],
+        "19": [
+            "level2",
+            "stadt",
+            "dorf",
+            "ort"
+        ],
+        "20": [
+            "level1",
+            "bundesland",
+            "kanton"
+        ],
+        "21": [
+            "ländercode",
+            "code"
+        ],
+        "22": [
+            "ländername",
+            "landname",
+            "land"
+        ],
+        "23": [
+            "postleitzahl",
+            "plz"
+        ],
+        "24": [
+            "kreditkartenname",
+            "namedeskarteninhabers",
+            "karteninhaber",
+            "kartenbesitzer",
+            "kontoinhaber"
+        ],
+        "25": [
+            "kreditkartenvorname"
+        ],
+        "26": [
+            "kreditkartenzweitname",
+            "kreditkartenzwischenname",
+            "kreditkartenmittelname"
+        ],
+        "27": [
+            "kreditkartennachname"
+        ],
+        "28": [
+            "kreditkartennummer",
+            "iban",
+            "kartennummer"
+        ],
+        "29": [
+            "verfallsdatum",
+            "läuftab",
+            "gültig",
+            "gültigbis"
+        ],
+        "30": [
+            "ablaufmonat",
+            "gültigbismonat",
+            "bismonat"
+        ],
+        "31": [
+            "ablaufjahr",
+            "gültigbisjahr",
+            "bisjahr"
+        ],
+        "32": [
+            "sicherheitscode",
+            "prüfziffer",
+            "csc",
+            "cvc",
+            "cvv",
+            "spc",
+            "ccid"
+        ],
+        "33": [
+            "zahlungsmethode",
+            "zahlungsanbieter",
+            "anbieter",
+            "visa",
+            "mastercard",
+            "paypal"
+        ],
+        "34": [
+            "währung",
+            "transaktionswährung",
+            "eur",
+            "usd",
+            "gbp",
+            "chf"
+        ],
+        "35": [
+            "transaktionsbetrag",
+            "betrag"
+        ],
+        "36": [
+            "sprache"
+        ],
+        "37": [
+            "geburtstag",
+            "geburtsdatum"
+        ],
+        "38": [
+            "geburtstagtag",
+            "tag"
+        ],
+        "39": [
+            "geburtstagmonat",
+            "monat"
+        ],
+        "40": [
+            "geburtsjahr"
+        ],
+        "41": [
+            "geschlecht",
+            "gender",
+            "geschlechtsidentität",
+            "identität",
+            "mann",
+            "frau",
+            "divers",
+            "transgender",
+            "trans",
+            "queer",
+            "other"
+        ],
+        "42": [
+            "url",
+            "link",
+            "homepage",
+            "webseite",
+            "seite"
+        ],
+        "43": [
+            "foto",
+            "bild",
+            "icon"
+        ],
+        "44": [
+            "tel",
+            "telefon",
+            "telefonnummer",
+            "handy",
+            "mobiltelefon",
+            "mobilnummer",
+            "mobilfunknummer",
+            "mobil"
+        ],
+        "45": [
+            "ländervorwahl",
+            "vorwahldeslandes",
+            "vorwahldeslands",
+            "internationalevorwahl"
+        ],
+        "46": [
+            "nationaletelefonnummer"
+        ],
+        "47": [
+            "vorwahl"
+        ],
         "48": [],
         "49": [],
         "50": [],
-        "51": ["durchwahl", "internenummer", "intern"],
-        "52": ["email", "emil", "emailadresse"],
-        "53": ["impp", "instantmessagingprotocol", "instantmessagingprotocolendpoint"]
+        "51": [
+            "durchwahl",
+            "internenummer",
+            "intern"
+        ],
+        "52": [
+            "email",
+            "emil",
+            "emailadresse"
+        ],
+        "53": [
+            "impp",
+            "instantmessagingprotocol",
+            "instantmessagingprotocolendpoint"
+        ]
+    },
+    "byLabel_NL": {
+        "1": [
+            "naam",
+            "volledigenaam"
+        ],
+        "2": [
+            "aanhef",
+            "titel",
+            "voorvoegsel"
+        ],
+        "3": [
+            "voornaam",
+            "roepnaam"
+        ],
+        "4": [
+            "tweedeNaam",
+            "tussenvoegsel",
+            "voorletters"
+        ],
+        "5": [
+            "achternaam",
+            "familienaam"
+        ],
+        "6": [
+            "naamtoevoeging",
+            "toevoeging",
+            "achtervoegsel"
+        ],
+        "7": [
+            "alias",
+            "artiestennaam",
+            "bijnaam"
+        ],
+        "8": [
+            "beroep",
+            "titel",
+            "functiebenaming",
+            "functie"
+        ],
+        "9": [
+            "gebruikersnaam",
+            "login"
+        ],
+        "10": [
+            "nieuwwachtwoord",
+            "nieuwpaswoord"
+        ],
+        "11": [
+            "huidigwachtwoord",
+            "huidigpaswoord",
+            "wachtwoord",
+            "paswoord"
+        ],
+        "12": [
+            "organisatie",
+            "bedrijf",
+            "onderneming",
+            "instelling"
+        ],
+        "13": [
+            "adres",
+            "straatHuisnummer"
+        ],
+        "14": [
+            "adresregel1",
+            "regel1",
+            "straat",
+            "huisnummer"
+        ],
+        "15": [
+            "adresregel2",
+            "regel2",
+            "huisnummer",
+            "appartement"
+        ],
+        "16": [
+            "adresregel3",
+            "regel3"
+        ],
+        "17": [
+            "niveau4"
+        ],
+        "18": [
+            "niveau3",
+            "wijk",
+            "district",
+            "deelgemeente"
+        ],
+        "19": [
+            "niveau2",
+            "woonplaats",
+            "gemeente",
+            "stad",
+            "dorp",
+            "plaats"
+        ],
+        "20": [
+            "niveau1",
+            "provincie"
+        ],
+        "21": [
+            "landcode",
+            "code"
+        ],
+        "22": [
+            "landnaam",
+            "land"
+        ],
+        "23": [
+            "postcode"
+        ],
+        "24": [
+            "kredtietkaart",
+            "kredietkaartnaam",
+            "bankkaart",
+            "bankkaartnaam",
+            "creditcard",
+            "creditcardnaam",
+            "naamKaarthouder",
+            "kaarthouder",
+            "kaarteigenaar",
+            "rekeninghouder"
+        ],
+        "25": [
+            "creditcardvoornaam",
+            "kredietkaartvoornaam",
+            "bankkaartvoornaam"
+        ],
+        "26": [
+            "creditcardtweedeNaam",
+            "creditcardtussenvoegsel",
+            "creditcardmiddelnaam",
+            "kredietkaarttweedeNaam",
+            "kredietkaarttussenvoegsel",
+            "kredietkaartmiddelnaam",
+            "bankkaarttweedeNaam",
+            "bankkaarttussenvoegsel",
+            "bankkaartdmiddelnaam"
+        ],
+        "27": [
+            "creditcardachternaam",
+            "kredietkaartachternaam",
+            "bankkaartachternaam"
+        ],
+        "28": [
+            "creditcardnummer",
+            "kredietkaartnummer",
+            "kaartnummer",
+            "bankkaartnumemr",
+            "iban"
+        ],
+        "29": [
+            "vervaldatum",
+            "vervalt",
+            "geldig",
+            "geldigTot"
+        ],
+        "30": [
+            "vervalmaand",
+            "geldigTotMaand"
+        ],
+        "31": [
+            "vervaljaar",
+            "geldigTotJaar"
+        ],
+        "32": [
+            "beveiligingscode",
+            "controlegetal",
+            "csc",
+            "cvc",
+            "cvv"
+        ],
+        "33": [
+            "betaalmethode",
+            "betaalwijze",
+            "betalingswijze",
+            "wijze van betalen",
+            "wijze van betaling",
+            "betaalaanbieder",
+            "aanbieder",
+            "visa",
+            "mastercard",
+            "paypal"
+        ],
+        "34": [
+            "valuta",
+            "transactievaluta",
+            "eur",
+            "usd",
+            "gbp",
+            "chf"
+        ],
+        "35": [
+            "bedrag",
+            "totaal",
+            "totaalbedrag"
+        ],
+        "36": [
+            "taal"
+        ],
+        "37": [
+            "verjaardag",
+            "geboortedatum",
+            "geborenOp"
+        ],
+        "38": [
+            "verjaardagdag",
+            "dag"
+        ],
+        "39": [
+            "verjaardagmaand",
+            "maand"
+        ],
+        "40": [
+            "geboortejaar",
+            "jaar"
+        ],
+        "41": [
+            "geslacht",
+            "gender",
+            "geslachtsidentiteit",
+            "identiteit",
+            "man",
+            "vrouw",
+            "man of vrouw",
+            "divers",
+            "transgender",
+            "trans",
+            "queer",
+            "anders",
+            "zeg ik liever niet"
+        ],
+        "42": [
+            "url",
+            "link",
+            "http",
+            "homepage",
+            "website"
+        ],
+        "43": [
+            "foto",
+            "afbeelding",
+            "icoon",
+            "avatar",
+            "profielfoto",
+            "upload"
+        ],
+        "44": [
+            "tel",
+            "telefoon",
+            "telefoonnummer",
+            "mobiel",
+            "gsm",
+            "werktelefoon",
+            "thuisnummer",
+        ],
+        "45": [
+            "landcode",
+            "landprefix",
+            "landvoorvoegsel",
+            "internationaleVoorbelcode"
+        ],
+        "46": [
+            "nationaalTelefoonnummer"
+        ],
+        "47": [
+            "netnummer"
+        ],
+        "48": [],
+        "49": [],
+        "50": [],
+        "51": [
+            "doorkiesnummer",
+            "internNummer"
+        ],
+        "52": [
+            "e-mailadres",
+            "emailadres",
+            "email",
+            "mail",
+            "mailadres",
+            "email adres"
+        ],
+        "53": [
+            "impp",
+            "instantMessagingProtocol",
+            "instantMessagingProtocolEndpoint"
+        ]
     },
     "byFormType_EN": {
-        "login": ["login", "signin"],
-        "signup": ["create", "signup", "register", "registration", "new", "newaccount"]
+        "login": [
+            "login",
+            "signin"
+        ],
+        "signup": [
+            "create",
+            "signup",
+            "register",
+            "registration",
+            "new",
+            "newaccount"
+        ]
     },
     "byFormType_DE": {
-        "login": ["login", "anmelden", "einloggen"],
-        "signup": ["erstellen", "neuanmelden", "neu", "registrieren", "registrierung"]
+        "login": [
+            "login",
+            "anmelden",
+            "einloggen"
+        ],
+        "signup": [
+            "erstellen",
+            "neuanmelden",
+            "neu",
+            "registrieren",
+            "registrierung"
+        ]
+    },
+    "byFormType_NL": {
+        "login": [
+            "login",
+            "log in",
+            "inloggen",
+            "aanloggen",
+            "aanmelden"
+        ],
+        "signup": [
+            "aanmelden",
+            "registreren",
+            "account aanmaken",
+            "profiel aanmaken",
+            "word lid",
+            "lid worden",
+            "nieuw profiel",
+            "nieuw account",
+            "nieuw"
+        ]
     }
 }


### PR DESCRIPTION
This pull request adds Dutch (Netherlands) and Belgian Dutch language labels to your extension. These labels have been tested on some internal sample pages and work as expected. Thank you for considering this merge request! If you approve, we can also add French labels.